### PR TITLE
Allow for multiple cmds to be run

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -89,8 +89,8 @@ def run_chef(nickname, nohup=None, stage=False):
                 sudo(cmd, user=CHEF_USER)
             else:
                 # Run in background
-                cmd_prefix = 'nohup '
-                cmd_suffix = ' & '
+                cmd_prefix = 'nohup bash -c "('
+                cmd_suffix = ' )" & '
                 cmd_sleep = '(' + cmd_prefix + cmd + cmd_suffix + ') && sleep 1'
                 sudo(cmd_sleep, user=CHEF_USER)  # via https://stackoverflow.com/a/43152236
                 nohupout = os.path.join(chef_run_dir, 'nohup.out')


### PR DESCRIPTION
nohup does not execute properly when multiple commands are thrown at it, such as `source credentials/crowdinkeys.env && ./chef.py -v --compress --reset --token={studio_token} lang=bn` or `SECRET_KEY=123 ./chef.py -v --compress --reset --token={studio_token} lang=bn`

This allows for multiple commands to be executed successfully.